### PR TITLE
format timestamp display in cancelled and completed orders

### DIFF
--- a/views/cancelledOrders.ejs
+++ b/views/cancelledOrders.ejs
@@ -40,7 +40,7 @@
           <td><%=tempDrink.flavors%></td>
           <td><%=tempDrink.toppings%></td>
           <td><%=tempDrink.instructions%></td>
-          <td><%=order.timestamp%></td>
+          <td><%=order.timestamp.split('/')[0]%></td>
           <% if(showButtons === true) { %>
           <td>
             <button

--- a/views/completed.ejs
+++ b/views/completed.ejs
@@ -40,7 +40,7 @@
           <td><%=tempDrink.flavors%></td>
           <td><%=tempDrink.toppings%></td>
           <td><%=tempDrink.instructions%></td>
-          <td><%=order.timestamp%></td>
+          <td><%=order.timestamp.split('/')[0]%></td>
           <% if(showButtons === true) { %>
           <td>
             <button


### PR DESCRIPTION
accept my pull request
This pull request includes changes to modify the display format of the `order.timestamp` in two different views. The changes ensure that only the first part of the timestamp (before the '/') is displayed.

Changes to timestamp display format:

* [`views/cancelledOrders.ejs`](diffhunk://#diff-6ec63153d8ba8f13f062e36a9072079d7880beec943c03c8dcb8f63b3456ed67L43-R43): Updated the `order.timestamp` to display only the part before the '/' character.
* [`views/completed.ejs`](diffhunk://#diff-c174d6c2bebb3ca569d62d955ea5420abf42ab8dd774002cbde61855807d1344L43-R43): Updated the `order.timestamp` to display only the part before the '/' character.